### PR TITLE
C#6.0 Compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 *.user
 *.userosscache
 *.sln.docstates
+.vs/
+*.VC.db
+*.VC.opendb
 
 # Build results
 [Dd]ebug/

--- a/Ext.ux.Highcharts/Chart.ux/BaseAreaRangeSerie.cs
+++ b/Ext.ux.Highcharts/Chart.ux/BaseAreaRangeSerie.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using System.Web.UI;
 using Ext.Net;
 
+[assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.AreaRangeSerie.js", "text/javascript")]
 namespace Ext.ux.Highcharts.ChartSeries
 {
     /// <summary>
@@ -14,7 +15,6 @@ namespace Ext.ux.Highcharts.ChartSeries
     /// See {@link Chart.ux.Highcharts.RangeSerie} class for more info
     /// 
     /// </summary>
-    [assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.AreaRangeSerie.js", "text/javascript")]
     public class BaseAreaRangeSerie : Series
     {
 

--- a/Ext.ux.Highcharts/Chart.ux/BaseAreaSerie.cs
+++ b/Ext.ux.Highcharts/Chart.ux/BaseAreaSerie.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using System.Web.UI;
 using Ext.Net;
 
+[assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.AreaSerie.js", "text/javascript")]
 namespace Ext.ux.Highcharts.ChartSeries
 {
     /// <summary>
@@ -13,7 +14,6 @@ namespace Ext.ux.Highcharts.ChartSeries
     /// 
     ///  See {@link Chart.ux.Highcharts.Serie} class for more info
     /// </summary>
-    [assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.AreaSerie.js", "text/javascript")]
     public partial class BaseAreaSerie : Series
     {
         protected override List<ResourceItem> Resources

--- a/Ext.ux.Highcharts/Chart.ux/BaseAreaSplineRangeSerie.cs
+++ b/Ext.ux.Highcharts/Chart.ux/BaseAreaSplineRangeSerie.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using System.Web.UI;
 using Ext.Net;
 
+[assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.AreaSplineRangeSerie.js", "text/javascript")]
 namespace Ext.ux.Highcharts.ChartSeries
 {
     /// <summary>
@@ -14,7 +15,6 @@ namespace Ext.ux.Highcharts.ChartSeries
     ///  See {@link Chart.ux.Highcharts.RangeSerie} class for more info
     /// 
     /// </summary>
-    [assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.AreaSplineRangeSerie.js", "text/javascript")]
 
     public partial class BaseAreaSplineRangeSerie : BaseRangeSerie
     {

--- a/Ext.ux.Highcharts/Chart.ux/BaseBarSerie.cs
+++ b/Ext.ux.Highcharts/Chart.ux/BaseBarSerie.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using System.Web.UI;
 using Ext.Net;
 
+[assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.BarSerie.js", "text/javascript")]
 namespace Ext.ux.Highcharts.ChartSeries
 {
     /// <summary>
@@ -13,7 +14,6 @@ namespace Ext.ux.Highcharts.ChartSeries
     /// 
     ///  See {@link Chart.ux.Highcharts.Serie} class for more info
     /// </summary>
-    [assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.BarSerie.js", "text/javascript")]
     public partial class BaseBarSerie : Series
     {
         protected override List<ResourceItem> Resources

--- a/Ext.ux.Highcharts/Chart.ux/BaseBoxPlotSerie.cs
+++ b/Ext.ux.Highcharts/Chart.ux/BaseBoxPlotSerie.cs
@@ -8,6 +8,7 @@ using System.Web.UI;
 using Ext.Net;
 
 
+[assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.BoxPlotSerie.js", "text/javascript")]
 namespace Ext.ux.Highcharts.ChartSeries
 {
     /// <summary>
@@ -25,7 +26,6 @@ namespace Ext.ux.Highcharts.ChartSeries
     ///          xField: 'date'
     ///      }]     
     /// </summary>
-    [assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.BoxPlotSerie.js", "text/javascript")]
     
     public partial class BaseBoxPlotSerie : Series
     {

--- a/Ext.ux.Highcharts/Chart.ux/BaseBubbleSerie.cs
+++ b/Ext.ux.Highcharts/Chart.ux/BaseBubbleSerie.cs
@@ -8,6 +8,7 @@ using System.Web.UI;
 using Ext.Net;
 using Ext.ux.Highcharts.ChartSeries;
 
+[assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.BubbleSerie.js", "text/javascript")]
 namespace Ext.ux.Highcharts.ChartSeries
 {
     /// <summary>
@@ -43,7 +44,6 @@ namespace Ext.ux.Highcharts.ChartSeries
     ///  
     ///  See {@link Chart.ux.Highcharts.Serie} class for more info
     /// </summary>
-    [assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.BubbleSerie.js", "text/javascript")]
     public partial class BaseBubbleSerie : Series
     {
 

--- a/Ext.ux.Highcharts/Chart.ux/BaseColumnRangeSerie.cs
+++ b/Ext.ux.Highcharts/Chart.ux/BaseColumnRangeSerie.cs
@@ -2,9 +2,9 @@ using System.Collections.Generic;
 using System.Web.UI;
 using Ext.Net;
 
+[assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.ColumnRangeSerie.js", "text/javascript")]
 namespace Ext.ux.Highcharts.ChartSeries
 {
-    [assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.ColumnRangeSerie.js", "text/javascript")]
     public partial class BaseColumnRangeSerie : BaseRangeSerie
     {
         protected override List<ResourceItem> Resources

--- a/Ext.ux.Highcharts/Chart.ux/BaseColumnSerie.cs
+++ b/Ext.ux.Highcharts/Chart.ux/BaseColumnSerie.cs
@@ -2,9 +2,9 @@ using System.Collections.Generic;
 using System.Web.UI;
 using Ext.Net;
 
+[assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.ColumnSerie.js", "text/javascript")]
 namespace Ext.ux.Highcharts.ChartSeries
 {
-    [assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.ColumnSerie.js", "text/javascript")]
     public partial class BaseColumnSerie : Series
     {
         protected override List<ResourceItem> Resources

--- a/Ext.ux.Highcharts/Chart.ux/BaseErrorBarSerie.cs
+++ b/Ext.ux.Highcharts/Chart.ux/BaseErrorBarSerie.cs
@@ -2,9 +2,9 @@ using System.Collections.Generic;
 using System.Web.UI;
 using Ext.Net;
 
+[assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.ErrorBarSerie.js", "text/javascript")]
 namespace Ext.ux.Highcharts.ChartSeries
 {
-    [assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.ErrorBarSerie.js", "text/javascript")]
     public partial class BaseErrorBarSerie : Series
     {
         protected override List<ResourceItem> Resources

--- a/Ext.ux.Highcharts/Chart.ux/BaseFunnelSerie.cs
+++ b/Ext.ux.Highcharts/Chart.ux/BaseFunnelSerie.cs
@@ -2,9 +2,9 @@ using System.Collections.Generic;
 using System.Web.UI;
 using Ext.Net;
 
+[assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.FunnelSerie.js", "text/javascript")]
 namespace Ext.ux.Highcharts.ChartSeries
 {
-    [assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.FunnelSerie.js", "text/javascript")]
     public partial class BaseFunnelSerie : WaterfallSeries
     {
         protected override List<ResourceItem> Resources

--- a/Ext.ux.Highcharts/Chart.ux/BaseGaugeSerie.cs
+++ b/Ext.ux.Highcharts/Chart.ux/BaseGaugeSerie.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Web.UI;
 using Ext.Net;
 
+[assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.GaugeSerie.js", "text/javascript")]
 namespace Ext.ux.Highcharts.ChartSeries
 {
     /// <summary>
@@ -31,7 +32,6 @@ namespace Ext.ux.Highcharts.ChartSeries
     ///           }
     ///       }]
     /// </summary>
-    [assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.GaugeSerie.js", "text/javascript")]
     public partial class BaseGaugeSerie : Series
     {
         protected override List<ResourceItem> Resources

--- a/Ext.ux.Highcharts/Chart.ux/BaseHeatmapSerie.cs
+++ b/Ext.ux.Highcharts/Chart.ux/BaseHeatmapSerie.cs
@@ -2,9 +2,9 @@ using System.Collections.Generic;
 using System.Web.UI;
 using Ext.Net;
 
+[assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.HeatmapSerie.js", "text/javascript")]
 namespace Ext.ux.Highcharts.ChartSeries
 {
-    [assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.HeatmapSerie.js", "text/javascript")]
     public partial class BaseHeatmapSerie : Series
     {
         protected override List<ResourceItem> Resources

--- a/Ext.ux.Highcharts/Chart.ux/BaseLineSerie.cs
+++ b/Ext.ux.Highcharts/Chart.ux/BaseLineSerie.cs
@@ -2,9 +2,9 @@ using System.Collections.Generic;
 using System.Web.UI;
 using Ext.Net;
 
+[assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.LineSerie.js", "text/javascript")]
 namespace Ext.ux.Highcharts.ChartSeries
 {
-    [assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.LineSerie.js", "text/javascript")]
     public partial class BaseLineSerie : Series
     {
         protected override List<ResourceItem> Resources

--- a/Ext.ux.Highcharts/Chart.ux/BaseMapBubbleSerie.cs
+++ b/Ext.ux.Highcharts/Chart.ux/BaseMapBubbleSerie.cs
@@ -3,13 +3,13 @@ using System.ComponentModel;
 using System.Web.UI;
 using Ext.Net;
 
+[assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.MapBubbleSerie.js", "text/javascript")]
 namespace Ext.ux.Highcharts.ChartSeries
 {
     /// <summary>
     ///  MapBubble Serie class is for plotting bubble data points on the map.
     ///  Expect z-axis value from the data store.
     /// </summary>
-    [assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.MapBubbleSerie.js", "text/javascript")]
     public partial class BaseMapBubbleSerie : Series
     {
         [ConfigOption]

--- a/Ext.ux.Highcharts/Chart.ux/BaseMapLineSerie.cs
+++ b/Ext.ux.Highcharts/Chart.ux/BaseMapLineSerie.cs
@@ -2,9 +2,9 @@ using System.Collections.Generic;
 using System.Web.UI;
 using Ext.Net;
 
+[assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.MapLineSerie.js", "text/javascript")]
 namespace Ext.ux.Highcharts.ChartSeries
 {
-    [assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.MapLineSerie.js", "text/javascript")]
     public partial class BaseMapLineSerie : BaseMapSerie
     {
         protected override List<ResourceItem> Resources

--- a/Ext.ux.Highcharts/Chart.ux/BaseMapPointSerie.cs
+++ b/Ext.ux.Highcharts/Chart.ux/BaseMapPointSerie.cs
@@ -2,9 +2,9 @@ using System.Collections.Generic;
 using System.Web.UI;
 using Ext.Net;
 
+[assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.MapPointSerie.js", "text/javascript")]
 namespace Ext.ux.Highcharts.ChartSeries
 {
-    [assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.MapPointSerie.js", "text/javascript")]
     public partial class BaseMapPointSerie : BaseMapSerie
     {
         protected override List<ResourceItem> Resources

--- a/Ext.ux.Highcharts/Chart.ux/BaseMapSerie.cs
+++ b/Ext.ux.Highcharts/Chart.ux/BaseMapSerie.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.Web.UI;
 using Ext.Net;
 
+[assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.MapSerie.js", "text/javascript")]
 namespace Ext.ux.Highcharts.ChartSeries
 {
     /// <summary>
@@ -47,7 +48,6 @@ namespace Ext.ux.Highcharts.ChartSeries
     ///          }
     ///      }]
     /// </summary>
-    [assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.MapSerie.js", "text/javascript")]
     public partial class BaseMapSerie : Series
     {
 

--- a/Ext.ux.Highcharts/Chart.ux/BasePieSerie.cs
+++ b/Ext.ux.Highcharts/Chart.ux/BasePieSerie.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Web.UI;
 using Ext.Net;
 
+[assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.PieSerie.js", "text/javascript")]
 namespace Ext.ux.Highcharts.ChartSeries
 {
     /// <summary>
@@ -115,7 +116,6 @@ namespace Ext.ux.Highcharts.ChartSeries
     ///  *colorField* option to map the field.
     ///
     /// </summary>
-    [assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.PieSerie.js", "text/javascript")]
     public partial class BasePieSerie : Series
     {
         protected override List<ResourceItem> Resources

--- a/Ext.ux.Highcharts/Chart.ux/BasePyramidSerie.cs
+++ b/Ext.ux.Highcharts/Chart.ux/BasePyramidSerie.cs
@@ -2,9 +2,9 @@ using System.Collections.Generic;
 using System.Web.UI;
 using Ext.Net;
 
+[assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.PyramidSerie.js", "text/javascript")]
 namespace Ext.ux.Highcharts.ChartSeries
 {
-    [assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.PyramidSerie.js", "text/javascript")]
     public partial class BasePyramidSerie : FunnelSeries
     {
         protected override List<ResourceItem> Resources

--- a/Ext.ux.Highcharts/Chart.ux/BaseRangeSerie.cs
+++ b/Ext.ux.Highcharts/Chart.ux/BaseRangeSerie.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using System.Web.UI;
 using Ext.Net;
 
+[assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.RangeSerie.js", "text/javascript")]
 namespace Ext.ux.Highcharts.ChartSeries
 {
     /// <summary>
@@ -28,7 +29,6 @@ namespace Ext.ux.Highcharts.ChartSeries
     ///         type: 'columnrange'
     ///     }]
     /// </summary>
-    [assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.RangeSerie.js", "text/javascript")]
     public partial class BaseRangeSerie : Ext.ux.Highcharts.ChartSeries.Series
     {
         [ConfigOption]

--- a/Ext.ux.Highcharts/Chart.ux/BaseScatterSerie.cs
+++ b/Ext.ux.Highcharts/Chart.ux/BaseScatterSerie.cs
@@ -3,9 +3,9 @@ using System.ComponentModel;
 using System.Web.UI;
 using Ext.Net;
 
+[assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.ScatterSerie.js", "text/javascript")]
 namespace Ext.ux.Highcharts.ChartSeries
 {
-    [assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.ScatterSerie.js", "text/javascript")]
     public partial class BaseScatterSerie : Series
     {
 

--- a/Ext.ux.Highcharts/Chart.ux/BaseSerie.cs
+++ b/Ext.ux.Highcharts/Chart.ux/BaseSerie.cs
@@ -11,6 +11,7 @@ using Ext.Net;
 //using Ext.ux.Highcharts.Series;
 using Newtonsoft.Json;
 
+[assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.Serie.js", "text/javascript")]
 namespace Ext.ux.Highcharts.ChartSeries
 {
     /// <summary>
@@ -103,7 +104,6 @@ namespace Ext.ux.Highcharts.ChartSeries
     /// 
     ///  For 3D column chart, users need to also specify/// chartConfig.chart.type* as 'column'. 
     /// </summary>
-    [assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.Serie.js", "text/javascript")]
     
     public partial class BaseSerie : Observable
     {

--- a/Ext.ux.Highcharts/Chart.ux/BaseSolidGaugeSerie.cs
+++ b/Ext.ux.Highcharts/Chart.ux/BaseSolidGaugeSerie.cs
@@ -2,9 +2,9 @@ using System.Collections.Generic;
 using System.Web.UI;
 using Ext.Net;
 
+[assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.SolidGaugeSerie.js", "text/javascript")]
 namespace Ext.ux.Highcharts.ChartSeries
 {
-    [assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.SolidGaugeSerie.js", "text/javascript")]
     public partial class BaseSolidGaugeSerie : Series
     {
         protected override List<ResourceItem> Resources

--- a/Ext.ux.Highcharts/Chart.ux/BaseSplineSerie.cs
+++ b/Ext.ux.Highcharts/Chart.ux/BaseSplineSerie.cs
@@ -2,9 +2,9 @@ using System.Collections.Generic;
 using System.Web.UI;
 using Ext.Net;
 
+[assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.SplineSerie.js", "text/javascript")]
 namespace Ext.ux.Highcharts.ChartSeries
 {
-    [assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.SplineSerie.js", "text/javascript")]
     public partial class BaseSplineSerie : Series
     {
         protected override List<ResourceItem> Resources

--- a/Ext.ux.Highcharts/Chart.ux/BaseWaterfallSerie.cs
+++ b/Ext.ux.Highcharts/Chart.ux/BaseWaterfallSerie.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.Web.UI;
 using Ext.Net;
 
+[assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.WaterfallSerie.js", "text/javascript")]
 namespace Ext.ux.Highcharts.ChartSeries
 {
     /// <summary>
@@ -40,7 +41,6 @@ namespace Ext.ux.Highcharts.ChartSeries
     /// 
     /// /
     /// </summary>
-    [assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.WaterfallSerie.js", "text/javascript")]
     public partial class BaseWaterfallSerie : Series
     {
 

--- a/Ext.ux.Highcharts/Chart.ux/Options3dResources.cs
+++ b/Ext.ux.Highcharts/Chart.ux/Options3dResources.cs
@@ -6,12 +6,12 @@ using System.Threading.Tasks;
 using System.Web.UI;
 using Ext.Net;
 
+[assembly: WebResource("Ext.ux.Highcharts.Resources.Highcharts.highcharts-3d.js", "text/javascript")]
 namespace Ext.ux.Highcharts.Chart
 {
     /// <summary>
     /// Class to bring in the 3d Resource Files
     /// </summary>
-    [assembly: WebResource("Ext.ux.Highcharts.Resources.Highcharts.highcharts-3d.js", "text/javascript")]
     
     public partial class Options3d
     {

--- a/Ext.ux.Highcharts/HighChart.cs
+++ b/Ext.ux.Highcharts/HighChart.cs
@@ -8,11 +8,11 @@ using System.Web.UI;
 using Ext.Net;
 
 
+[assembly: WebResource("Ext.ux.Highcharts.Resources.Highcharts.adapters.standalone-framework.js", "text/javascript")]
+[assembly: WebResource("Ext.ux.Highcharts.Resources.Highcharts.highcharts.src.js", "text/javascript")]
+[assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.js", "text/javascript")]
 namespace Ext.ux.Highcharts
 {
-    [assembly: WebResource("Ext.ux.Highcharts.Resources.Highcharts.adapters.standalone-framework.js", "text/javascript")]
-    [assembly: WebResource("Ext.ux.Highcharts.Resources.Highcharts.highcharts.src.js", "text/javascript")]
-    [assembly: WebResource("Ext.ux.Highcharts.Resources.Chart.ux.Highcharts.js", "text/javascript")]
 
     [Designer(typeof(EmptyDesigner))]
     //[DefaultProperty("")]


### PR DESCRIPTION
https://github.com/dotnet/roslyn/commit/5f53a44f0ba046226e379df16d0777012b3fa861#diff-bc0650bfa452c22c1bd0f042c499a86eR86
Breaking Change: CS1730 is now reported when an assembly or module level attribute target is used to when applying an attribute to a member (Bug 528676).